### PR TITLE
Mitmach-Guide: Einzelinstanz, Langname (v3.4) hinzugefügt - bitte prüfen

### DIFF
--- a/_pages/Metrics-Howto.md
+++ b/_pages/Metrics-Howto.md
@@ -143,7 +143,7 @@ rest_command:
         "api_key": ".......",
         "heating_id": ".......",
         "thermal_energy_kwh": "{{ states('sensor.boiler_total_energy') }}",
-        "electrical_energy_kwh": "{{ states('sensor.boiler_total_energy_consumption') }}",
+        "electrical_energy_kwh": "{{ states('sensor.boiler_meter_total') }}",
         "thermal_energy_heating_kwh": "{{ states('sensor.boiler_energy_heating') }}",
         "electrical_energy_heating_kwh": "{{ states('sensor.boiler_meter_heating') }}",
         "outdoor_temperature_c": "{{ states('sensor.boiler_outside_temperature') }}",


### PR DESCRIPTION
Hallo,
die MQTT-Einstellungen meines EMS stehen auf Entitäts-ID-Format = "Einzelinstanz, Langname (v3.4)" und die technischen Namen meiner Entitäten matchen nicht mit den hier im Standard genutzten Formaten.
Da ich schon "zu tief drin bin" und diverse Dashboards, Automatisierungen meine Namen benutzen, und ich noch keine komplette Umschlüsselungstabelle habe (müsste man vermutlich über die Beschreibungen matchen?), bleibe ich erstmal dabei. Würde aber dennoch gerne meine Daten beisteuern.

Hier einmal meine versuchte Umschlüsselung der für die Metriken benötigten Entitäten inklusive Titel des Sensors und dem aktuellen Wert.

Vor dem Merge bitte ich um einen Plausibilitäts-Check. Danke!



| id für API | Sensor Einzelinstanz MQTT-Namen (v3.5 und v3.6) | Einzelinstanz Langnamen (v3.4) | Sensortitel | Aktueller Wert |
| --- | --- | --- | --- | --- |
| thermal_energy_kwh | {{ states('sensor.boiler_nrgtotal') }} | boiler_total_energy | Gesamtenergie | 3640.26 kWh |
| electrical_energy_kwh | {{ states('sensor.boiler_metertotal') }} | ~~sensor.boiler_total_energy_consumption~~ sensor.boiler_meter_total | ~~Gesamtenergieverbrauch~~ Gesamtmessung | 1263 kWh |
| thermal_energy_heating_kwh | {{ states('sensor.boiler_nrgheat') }} | sensor.boiler_energy_heating | Energie Heizen | 2429.58 kWh |
| electrical_energy_heating_kwh | {{ states('sensor.boiler_meterheat') }} | boiler_meter_heating | Messung Heizen | 835.35 kWh |
| outdoor_temperature_c | {{ states('sensor.boiler_outdoortemp') }} | sensor.boiler_outside_temperature | Außentemperatur | -0,9 °C |
| flow_temperature_c | {{ states('sensor.boiler_curflowtemp') }} | sensor.boiler_current_flow_temperature | Aktuelle Vorlauftemperatur | 29,4 °C |






